### PR TITLE
Add Jailbreak codes to AppleTV.ir

### DIFF
--- a/AppleTV.ir
+++ b/AppleTV.ir
@@ -60,3 +60,15 @@ type: parsed
 protocol: NECext
 address: EE 87 00 00
 command: 5C 01 00 00
+#
+name: Down_menu
+type: parsed
+protocol: NECext
+address: EE 87 00 00
+command: 19 66 00 00
+#
+name: Menu_play
+type: parsed
+protocol: NECext
+address: EE 87 00 00
+command: 61 66 00 00


### PR DESCRIPTION
Added the codes for pressing the down arrow and the menu button as well as pressing the play pause and the menu button at the same time, often used for jailbreaking.